### PR TITLE
Apply the comment color to git commit messages

### DIFF
--- a/colors/onedark.vim
+++ b/colors/onedark.vim
@@ -214,7 +214,7 @@ call s:h("diffRemoved", { "fg": s:red })
 " | Git Highlighting |
 " +------------------+
 
-call s:h("gitcommitComment", {})
+call s:h("gitcommitComment", { "fg": s:comment_grey })
 call s:h("gitcommitUnmerged", { "fg": s:green })
 call s:h("gitcommitOnBranch", {})
 call s:h("gitcommitBranch", { "fg": s:purple })

--- a/colors/onedark.vim
+++ b/colors/onedark.vim
@@ -148,7 +148,7 @@ call s:h("DiffDelete", { "fg": s:red }) " diff mode: Deleted line
 call s:h("DiffText", { "fg": s:blue }) " diff mode: Changed text within a changed line
 call s:h("ErrorMsg", {}) " error messages on the command line
 call s:h("VertSplit", { "fg": s:vertsplit }) " the column separating vertically split windows
-call s:h("Folded", {}) " line used for closed folds
+call s:h("Folded", { "fg": s:comment_grey }) " line used for closed folds
 call s:h("FoldColumn", {}) " 'foldcolumn'
 call s:h("SignColumn", {}) " column where signs are displayed
 call s:h("IncSearch", { "fg": s:visual_black, "bg": s:visual_grey }) " 'incsearch' highlighting; also used for the text replaced with ":s///c"


### PR DESCRIPTION
Turns out it was pretty simple :)

![screen shot 2016-05-08 at 17 29 03](https://cloud.githubusercontent.com/assets/360703/15098991/66c5d032-1542-11e6-8f7c-66d7f670ab39.png)

Fix #21 
