### PR TITLE
Add highlighting for Markdown

### DIFF
--- a/colors/onedark.vim
+++ b/colors/onedark.vim
@@ -289,6 +289,31 @@ call s:h("sassMixin", { "fg": s:purple })
 call s:h("sassMixinName", { "fg": s:blue })
 call s:h("sassMixing", { "fg": s:purple })
 
+" Markdown
+call s:h("markdownCode", { "fg": s:green })
+call s:h("markdownCodeBlock", { "fg": s:green })
+call s:h("markdownCodeDelimiter", { "fg": s:green })
+call s:h("markdownHeadingDelimiter", { "fg": s:red })
+call s:h("markdownRule", { "fg": s:comment_grey })
+call s:h("markdownHeadingRule", { "fg": s:comment_grey })
+call s:h("markdownH1", { "fg": s:red })
+call s:h("markdownH2", { "fg": s:red })
+call s:h("markdownH3", { "fg": s:red })
+call s:h("markdownH4", { "fg": s:red })
+call s:h("markdownH5", { "fg": s:red })
+call s:h("markdownH6", { "fg": s:red })
+call s:h("markdownIdDelimiter", { "fg": s:purple })
+call s:h("markdownId", { "fg": s:purple })
+call s:h("markdownBlockquote", { "fg": s:comment_grey })
+call s:h("markdownItalic", { "fg": s:purple, "gui": "italic", "cterm": "italic" })
+call s:h("markdownBold", { "fg": s:dark_yellow })
+call s:h("markdownListMarker", { "fg": s:red })
+call s:h("markdownOrderedListMarker", { "fg": s:red })
+call s:h("markdownIdDeclaration", { "fg": s:blue })
+call s:h("markdownLinkText", { "fg": s:blue })
+call s:h("markdownLinkDelimiter", { "fg": s:white })
+call s:h("markdownUrl", { "fg": s:purple })
+
 " +---------------------+
 " | Plugin Highlighting |
 " +---------------------+


### PR DESCRIPTION
Have tried to get this as close to Atom as possible, but note that I don't have italics enabled so couldn't test that. Also not sure on bold?

Atom seems to leave indented code blocks and underlined headings as plain white. I opted to add colour in those scenarios as it's useful, especially with code blocks.

Test file - https://github.com/caleb/gruvbox-syntax-atom/blob/master/spec/markdown.md

**Atom**
![screen shot 2016-05-10 at 15 44 28](https://cloud.githubusercontent.com/assets/360703/15150676/1fe9c8e6-16c6-11e6-90b5-189828b64c4f.png)

**Vim**
![screen shot 2016-05-10 at 15 43 34](https://cloud.githubusercontent.com/assets/360703/15150682/2649cc7c-16c6-11e6-8ea9-f950d591243c.png)