### PR TITLE
Add HTML syntax highlighting

### DIFF
--- a/colors/onedark.vim
+++ b/colors/onedark.vim
@@ -184,6 +184,18 @@ call s:h("WildMenu", {}) " current match in 'wildmenu' completion
 " | Language-Specific Highlighting |
 " +--------------------------------+
 
+" HTML
+call s:h("htmlTagName", { "fg": s:red })
+call s:h("htmlSpecialTagName", { "fg": s:red })
+call s:h("htmlSpecialChar", { "fg": s:dark_yellow })
+call s:h("htmlTag", { "fg": s:white })
+call s:h("htmlLink", { "fg": s:purple })
+call s:h("htmlEndTag", { "fg": s:white })
+call s:h("htmlArg", { "fg": s:dark_yellow })
+call s:h("htmlH1", { "fg": s:white })
+call s:h("Title", { "fg": s:white })
+
+" JavaScript
 call s:h("javaScriptBraces", { "fg": s:white })
 call s:h("javaScriptIdentifier", { "fg": s:purple })
 call s:h("javaScriptNull", { "fg": s:dark_yellow })


### PR DESCRIPTION
Sorry for the PR spam :)

Test: https://github.com/caleb/gruvbox-syntax-atom/blob/master/spec/html.html

**Atom**
![screen shot 2016-05-10 at 15 21 25](https://cloud.githubusercontent.com/assets/360703/15149867/1e07eb0a-16c3-11e6-9e1e-66c11c868ce5.png)

**Vim**
![screen shot 2016-05-10 at 15 21 11](https://cloud.githubusercontent.com/assets/360703/15149873/23efe32e-16c3-11e6-99fd-541292275dcd.png)