### PR TITLE
Tweak JavaScript highlighting

### DIFF
--- a/colors/onedark.vim
+++ b/colors/onedark.vim
@@ -60,10 +60,10 @@ endfunction
 " +-----------------+
 
 let s:red = { "gui": "#E06C75", "cterm": "204", "cterm16": "1" } " Alternate cterm: 168
-"let s:dark_red = { "gui": "#e64040", "cterm": "196", "cterm16": "9" }
+let s:dark_red = { "gui": "#e64040", "cterm": "196", "cterm16": "9" }
 
 let s:green = { "gui": "#98C379", "cterm": "114", "cterm16": "2" }
-"let s:dark_green = { "gui": "#6dc35c", "cterm": "36", "cterm16": "10" }
+let s:dark_green = { "gui": "#6dc35c", "cterm": "36", "cterm16": "10" }
 
 let s:yellow = { "gui": "#E5C07B", "cterm": "180", "cterm16": "3" }
 let s:dark_yellow = { "gui": "#D19A66", "cterm": "173", "cterm16": "11" }
@@ -219,8 +219,34 @@ call s:h("htmlTagName", { "fg": s:red })
 " JavaScript
 call s:h("javaScriptBraces", { "fg": s:white })
 call s:h("javaScriptIdentifier", { "fg": s:purple })
+call s:h("javaScriptReserved", { "fg": s:purple })
+call s:h("javaScriptFunction", { "fg": s:purple })
 call s:h("javaScriptNull", { "fg": s:dark_yellow })
 call s:h("javaScriptNumber", { "fg": s:dark_yellow })
+call s:h("javaScriptRequire", { "fg": s:cyan })
+" https://github.com/pangloss/vim-javascript
+call s:h("jsStorageClass", { "fg": s:purple })
+call s:h("jsFunction", { "fg": s:purple })
+call s:h("jsClassKeywords", { "fg": s:purple })
+call s:h("jsThis", { "fg": s:red })
+call s:h("jsTemplateBraces", { "fg": s:dark_red })
+call s:h("jsTemplateVar", { "fg": s:dark_green })
+call s:h("jsOperator", { "fg": s:purple })
+call s:h("jsUndefined", { "fg": s:dark_yellow })
+call s:h("jsThis", { "fg": s:red })
+call s:h("jsArrowFunction", { "fg": s:purple })
+call s:h("jsFuncCall", { "fg": s:blue })
+call s:h("jsNull", { "fg": s:dark_yellow })
+call s:h("jsGlobalObjects", { "fg": s:yellow })
+" https://github.com/othree/yajs.vim
+call s:h("javascriptEndColons", { "fg": s:white })
+call s:h("javascriptFuncArg", { "fg": s:white })
+call s:h("javascriptObjectLabel", { "fg": s:white })
+call s:h("javascriptFuncKeyword", { "fg": s:purple })
+call s:h("javascriptVariable", { "fg": s:purple })
+call s:h("javascriptPropertyName", { "fg": s:green })
+call s:h("javascriptTemplateSB", { "fg": s:dark_red })
+call s:h("javascriptArrowFunc", { "fg": s:purple })
 
 " JSON
 call s:h("jsonKeyword", { "fg": s:red })


### PR DESCRIPTION
This tweaks a couple of the base colours and I also added some additional colours provided by the [vim-javascript](https://github.com/pangloss/vim-javascript) package. It seems one of the most popular and is included in [polyglot](https://github.com/sheerun/vim-polyglot). I also added some colours for [yajs](https://github.com/othree/yajs.vim) as that seems the other popular choice.

**Atom** 
![screen shot 2016-05-10 at 17 10 52](https://cloud.githubusercontent.com/assets/360703/15154013/7893c6b0-16d3-11e6-9ebe-10d0c512339d.png)

**Vim** (standard)
![screen shot 2016-05-10 at 17 07 52](https://cloud.githubusercontent.com/assets/360703/15154031/8a4582b8-16d3-11e6-944e-297f9443c2a4.png)

**Vim** (pangloss)
![screen shot 2016-05-10 at 17 08 21](https://cloud.githubusercontent.com/assets/360703/15154043/96e2adfc-16d3-11e6-81fa-e32675489709.png)

**Vim** (yajs)
![screen shot 2016-05-10 at 17 39 51](https://cloud.githubusercontent.com/assets/360703/15154593/48fca50e-16d6-11e6-9b1e-3667364b8fdd.png)

Also, here is the jQuery source screenshot:

**Atom**
![screen shot 2016-05-10 at 17 16 55](https://cloud.githubusercontent.com/assets/360703/15154626/6ba42a78-16d6-11e6-9381-bd8e14fc5a39.png)

**Vim** (standard)
![screen shot 2016-05-10 at 17 16 47](https://cloud.githubusercontent.com/assets/360703/15154651/8f588f4a-16d6-11e6-8eff-58401cf1df78.png)

**Vim** (pangloss)
![screen shot 2016-05-10 at 17 17 29](https://cloud.githubusercontent.com/assets/360703/15154657/99336526-16d6-11e6-96a1-f2028295ede1.png)

Personally I think Atom is a bit overkill with the way it throws reds and blues together and I think the Vim version is much easier on the eyes