### PR TITLE
Add highlighting of JSON errors

### DIFF
--- a/colors/onedark.vim
+++ b/colors/onedark.vim
@@ -289,9 +289,15 @@ call s:h("javascriptTemplateSB", { "fg": s:dark_red })
 call s:h("javascriptVariable", { "fg": s:purple })
 
 " JSON
+call s:h("jsonCommentError", { "fg": s:white })
 call s:h("jsonKeyword", { "fg": s:red })
 call s:h("jsonQuote", { "fg": s:white })
+call s:h("jsonMissingCommaError", { "fg": s:red, "gui": "reverse" })
+call s:h("jsonNoQuotesError", { "fg": s:red, "gui": "reverse" })
+call s:h("jsonNumError", { "fg": s:red, "gui": "reverse" })
 call s:h("jsonString", { "fg": s:green })
+call s:h("jsonStringSQError", { "fg": s:red, "gui": "reverse" })
+call s:h("jsonSemicolonError", { "fg": s:red, "gui": "reverse" })
 
 " Markdown
 call s:h("markdownCode", { "fg": s:green })


### PR DESCRIPTION
Makes it easier to spot errors at a glance:

**Atom**
<img width="543" alt="screen shot 2016-05-21 at 22 36 42" src="https://cloud.githubusercontent.com/assets/360703/15450956/c9ecd446-1fa4-11e6-9359-802361fdc33d.png">

**Vim**
<img width="568" alt="screen shot 2016-05-21 at 22 36 16" src="https://cloud.githubusercontent.com/assets/360703/15450958/d7e972c0-1fa4-11e6-9c0b-d055ba8a2386.png">

**Neovim**
<img width="564" alt="screen shot 2016-05-21 at 22 34 42" src="https://cloud.githubusercontent.com/assets/360703/15450959/deb58c74-1fa4-11e6-8303-8d4be5e7b6cf.png">

Usage of `reverse` taken from - http://vi.stackexchange.com/questions/3288/override-cursorline-background-color-by-syntax-highlighting
