### PR TITLE
Improved JSDoc Colors in YAJS

### DIFF
--- a/colors/onedark.vim
+++ b/colors/onedark.vim
@@ -291,6 +291,7 @@ call s:h("javascriptTemplateSB", { "fg": s:dark_red })
 call s:h("javascriptVariable", { "fg": s:purple })
 call s:h("javascriptDocNotation", { "fg": s:purple })
 call s:h("javascriptDocTags", { "fg": s:purple })
+call s:h("javascriptDocParamName", { "fg": s:blue })
 
 " JSON
 call s:h("jsonCommentError", { "fg": s:white })

--- a/colors/onedark.vim
+++ b/colors/onedark.vim
@@ -289,6 +289,8 @@ call s:h("javascriptOpSymbols", { "fg": s:cyan })
 call s:h("javascriptPropertyName", { "fg": s:green })
 call s:h("javascriptTemplateSB", { "fg": s:dark_red })
 call s:h("javascriptVariable", { "fg": s:purple })
+call s:h("javascriptDocNotation", { "fg": s:blue })
+call s:h("javascriptDocTags", { "fg": s:blue })
 
 " JSON
 call s:h("jsonCommentError", { "fg": s:white })

--- a/colors/onedark.vim
+++ b/colors/onedark.vim
@@ -289,8 +289,8 @@ call s:h("javascriptOpSymbols", { "fg": s:cyan })
 call s:h("javascriptPropertyName", { "fg": s:green })
 call s:h("javascriptTemplateSB", { "fg": s:dark_red })
 call s:h("javascriptVariable", { "fg": s:purple })
-call s:h("javascriptDocNotation", { "fg": s:blue })
-call s:h("javascriptDocTags", { "fg": s:blue })
+call s:h("javascriptDocNotation", { "fg": s:purple })
+call s:h("javascriptDocTags", { "fg": s:purple })
 
 " JSON
 call s:h("jsonCommentError", { "fg": s:white })


### PR DESCRIPTION
Before:
![vim before](https://cloud.githubusercontent.com/assets/5783816/15683417/3df15532-2730-11e6-8a07-a4c649dfc69c.png)
After:
![vim after](https://cloud.githubusercontent.com/assets/5783816/15683568/12c17cce-2731-11e6-8d1f-4517c56da397.png)

EDIT: changed screenshot