### PR TITLE
Add colour for JSON boolean and number

### DIFF
--- a/colors/onedark.vim
+++ b/colors/onedark.vim
@@ -303,6 +303,8 @@ call s:h("javascriptVariable", { "fg": s:purple })
 " JSON
 call s:h("jsonCommentError", { "fg": s:white })
 call s:h("jsonKeyword", { "fg": s:red })
+call s:h("jsonBoolean", { "fg": s:dark_yellow })
+call s:h("jsonNumber", { "fg": s:dark_yellow })
 call s:h("jsonQuote", { "fg": s:white })
 call s:h("jsonMissingCommaError", { "fg": s:red, "gui": "reverse" })
 call s:h("jsonNoQuotesError", { "fg": s:red, "gui": "reverse" })


### PR DESCRIPTION
This works correctly in vanilla Vim but with polyglot they show up white. Figured no harm in being explicit

<img width="248" alt="screen shot 2016-08-23 at 22 34 50" src="https://cloud.githubusercontent.com/assets/360703/17910674/d2a4d440-6981-11e6-8116-aa0cd1360009.png">
