### PR TITLE
Updated git commit color so header overflow is red

### DIFF
--- a/build/templates/onedark.template.vim
+++ b/build/templates/onedark.template.vim
@@ -495,6 +495,7 @@ call s:h("gitcommitSelectedFile", { "fg": s:green })
 call s:h("gitcommitUnmergedFile", { "fg": s:yellow })
 call s:h("gitcommitFile", {})
 call s:h("gitcommitSummary", { "fg": s:white })
+call s:h("gitcommitOverflow", { "fg": s:red })
 hi link gitcommitNoBranch gitcommitBranch
 hi link gitcommitUntracked gitcommitComment
 hi link gitcommitDiscarded gitcommitComment

--- a/colors/onedark.vim
+++ b/colors/onedark.vim
@@ -495,6 +495,7 @@ call s:h("gitcommitSelectedFile", { "fg": s:green })
 call s:h("gitcommitUnmergedFile", { "fg": s:yellow })
 call s:h("gitcommitFile", {})
 call s:h("gitcommitSummary", { "fg": s:white })
+call s:h("gitcommitOverflow", { "fg": s:red })
 hi link gitcommitNoBranch gitcommitBranch
 hi link gitcommitUntracked gitcommitComment
 hi link gitcommitDiscarded gitcommitComment


### PR DESCRIPTION
Before:

<img width="570" alt="screenshot 2017-04-25 16 29 10" src="https://cloud.githubusercontent.com/assets/7340772/25406532/0162c9cc-29d5-11e7-8c0d-7597529db480.png">

After:

<img width="570" alt="screenshot 2017-04-25 16 28 42" src="https://cloud.githubusercontent.com/assets/7340772/25406541/08a83de8-29d5-11e7-9214-bd3fd97ba68a.png">
