### PR TITLE
Fix quickfix current line

### DIFF
--- a/colors/onedark.vim
+++ b/colors/onedark.vim
@@ -201,7 +201,8 @@ call s:h("PmenuSel", { "fg": s:black, "bg": s:blue }) " Popup menu: selected ite
 call s:h("PmenuSbar", { "bg": s:special_grey }) " Popup menu: scrollbar.
 call s:h("PmenuThumb", { "bg": s:white }) " Popup menu: Thumb of the scrollbar.
 call s:h("Question", { "fg": s:purple }) " hit-enter prompt and yes/no questions
-call s:h("Search", { "fg": s:black, "bg": s:yellow }) " Last search pattern highlighting (see 'hlsearch'). Also used for highlighting the current line in the quickfix window and similar items that need to stand out.
+call s:h("Search", { "fg": s:black, "bg": s:yellow }) " Last search pattern highlighting (see 'hlsearch'). Also used by few other items that need to stand out.
+call s:h("QuickFixLine", { "fg": s:black, "bg": s:yellow }) " Used for highlighting the current line in the quickfix window.
 call s:h("SpecialKey", { "fg": s:special_grey }) " Meta and special keys listed with ":map", also for text used to show unprintable characters in the text, 'listchars'. Generally: text that is displayed differently from what it really is.
 call s:h("SpellBad", { "fg": s:red, "gui": "underline", "cterm": "underline" }) " Word that is not recognized by the spellchecker. This will be combined with the highlighting used otherwise.
 call s:h("SpellCap", { "fg": s:dark_yellow }) " Word that should start with a capital. This will be combined with the highlighting used otherwise.


### PR DESCRIPTION
Seems few days ago was introduced a new option for highlight.
Now [QuickFixLine](https://github.com/vim/vim/search?utf8=%E2%9C%93&q=QuickFixLine&type=) is responsible for setting the color for the current
line in Quickfix list.

Before the fixing:
![without-fix](https://user-images.githubusercontent.com/680356/28148428-169d7a56-675d-11e7-9380-faee49fc71ca.png)

After the fixing:
![fixed](https://user-images.githubusercontent.com/680356/28148443-26cd1f12-675d-11e7-8361-af6506aac30d.png)

Vim don't throw any exception for invalid keys used in `call s:h("key_group", ...)`. So it shouldn't affect the users that still using the previous versions.

My VIM version: `VIM - Vi IMproved 8.0 (2016 Sep 12, compiled Jul 12 2017 08:56:45)`
