### PR TITLE
Expose function for extending highlight group.

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,11 @@ if (has("autocmd") && !has("gui_running"))
 end
 ```
 
+If you want to change only some parts of highlight group, you can use `onedark#extend_highlight` that will change only keys you provide. For example, if you want functions to be bold in GUI, you can do something like this:
+```vim
+call onedark#extend_highlight("Function", { "gui": "bold" })
+```
+
 You can also override a color across all highlights by adding the color definitions to the `g:onedark_color_overrides` dictionary in your `~/.vimrc` like so:
 
 ```vim

--- a/colors/onedark.vim
+++ b/colors/onedark.vim
@@ -52,6 +52,7 @@ endif
 set t_Co=256
 
 let g:colors_name="onedark"
+let s:group_colors = {}
 
 " Set to "256" for 256-color terminals, or
 " set to "16" to use your terminal emulator's native colors
@@ -69,36 +70,43 @@ endif
 
 " This function is based on one from FlatColor: https://github.com/MaxSt/FlatColor/
 " Which in turn was based on one found in hemisu: https://github.com/noahfrederick/vim-hemisu/
-function! s:h(group, style)
+function! s:h(group, style, ...)
+  let a:highlight = a:0 > 0 ? extend(s:group_colors[a:group], a:style) : a:style
   if g:onedark_terminal_italics == 0
-    if has_key(a:style, "cterm") && a:style["cterm"] == "italic"
-      unlet a:style.cterm
+    if has_key(a:highlight, "cterm") && a:highlight["cterm"] == "italic"
+      unlet a:highlight.cterm
     endif
-    if has_key(a:style, "gui") && a:style["gui"] == "italic"
-      unlet a:style.gui
+    if has_key(a:highlight, "gui") && a:highlight["gui"] == "italic"
+      unlet a:highlight.gui
     endif
   endif
+
   if g:onedark_termcolors == 16
-    let l:ctermfg = (has_key(a:style, "fg") ? a:style.fg.cterm16 : "NONE")
-    let l:ctermbg = (has_key(a:style, "bg") ? a:style.bg.cterm16 : "NONE")
+    let l:ctermfg = (has_key(a:highlight, "fg") ? a:highlight.fg.cterm16 : "NONE")
+    let l:ctermbg = (has_key(a:highlight, "bg") ? a:highlight.bg.cterm16 : "NONE")
   else
-    let l:ctermfg = (has_key(a:style, "fg") ? a:style.fg.cterm : "NONE")
-    let l:ctermbg = (has_key(a:style, "bg") ? a:style.bg.cterm : "NONE")
+    let l:ctermfg = (has_key(a:highlight, "fg") ? a:highlight.fg.cterm : "NONE")
+    let l:ctermbg = (has_key(a:highlight, "bg") ? a:highlight.bg.cterm : "NONE")
   endif
   execute "highlight" a:group
-    \ "guifg="   (has_key(a:style, "fg")    ? a:style.fg.gui   : "NONE")
-    \ "guibg="   (has_key(a:style, "bg")    ? a:style.bg.gui   : "NONE")
-    \ "guisp="   (has_key(a:style, "sp")    ? a:style.sp.gui   : "NONE")
-    \ "gui="     (has_key(a:style, "gui")   ? a:style.gui      : "NONE")
+    \ "guifg="   (has_key(a:highlight, "fg")    ? a:highlight.fg.gui   : "NONE")
+    \ "guibg="   (has_key(a:highlight, "bg")    ? a:highlight.bg.gui   : "NONE")
+    \ "guisp="   (has_key(a:highlight, "sp")    ? a:highlight.sp.gui   : "NONE")
+    \ "gui="     (has_key(a:highlight, "gui")   ? a:highlight.gui      : "NONE")
     \ "ctermfg=" . l:ctermfg
     \ "ctermbg=" . l:ctermbg
-    \ "cterm="   (has_key(a:style, "cterm") ? a:style.cterm    : "NONE")
+    \ "cterm="   (has_key(a:highlight, "cterm") ? a:highlight.cterm    : "NONE")
+  let s:group_colors[a:group] = a:highlight
 endfunction
 
 " public {{{
 
 function! onedark#set_highlight(group, style)
   call s:h(a:group, a:style)
+endfunction
+
+function! onedark#extend_highlight(group, style)
+  call s:h(a:group, a:style, 1)
 endfunction
 
 " }}}


### PR DESCRIPTION
Hi,

I really like this color scheme, but i miss bold font. I like to use it for functions, statements, etc.
I tried using `onedark#set_highlight`, but that requires you to pass in whole highlight dictionary, where i wanted only to append `gui=bold` to some parts.

I added `onedark#extend_highlight` which will use vimscript native `extend()` function to change certain highlight option within a highlight group. So with this, i can easily extend my highlight group to be bold like this:
```vim
call onedark#extend_highlight("Function", { "gui": "bold" })
```