### PR TITLE
Make only the changed text in a changed line be highlighted

### DIFF
--- a/colors/onedark.vim
+++ b/colors/onedark.vim
@@ -207,9 +207,9 @@ else
 endif
 call s:h("Directory", { "fg": s:blue }) " directory names (and other special names in listings)
 call s:h("DiffAdd", { "bg": s:green, "fg": s:black }) " diff mode: Added line
-call s:h("DiffChange", { "bg": s:yellow, "fg": s:black }) " diff mode: Changed line
+highlight clear DiffChange " diff mode: Changed line
 call s:h("DiffDelete", { "bg": s:red, "fg": s:black }) " diff mode: Deleted line
-call s:h("DiffText", { "bg": s:black, "fg": s:yellow }) " diff mode: Changed text within a changed line
+call s:h("DiffText", { "bg": s:yellow, "fg": s:black }) " diff mode: Changed text within a changed line
 call s:h("ErrorMsg", { "fg": s:red }) " error messages on the command line
 call s:h("VertSplit", { "fg": s:vertsplit }) " the column separating vertically split windows
 call s:h("Folded", { "fg": s:comment_grey }) " line used for closed folds


### PR DESCRIPTION
When Vim detects in diff mode that only part of a line is different, the line is highlighted as the group `DiffChange`, and the part of the line that is changed is highlighted as `DiffText`.

This colorscheme sets `DiffChange` to be black text on yellow background, and `DiffText` to be yellow text on black background.

It should probably be the other way around. `DiffText` should be the one highlighted with a yellow background, so as to stand out as the only changes in the line. And the rest of a `DiffChange` line should have no special highlighting.

I used `highlight clear DiffChange` for that last part, because `s:h` provides no way to do this AFAICT.