### PR TITLE
Add a tweak for fish shell scripts

### DIFF
--- a/colors/onedark.vim
+++ b/colors/onedark.vim
@@ -283,6 +283,10 @@ call s:h("cssSelectorOp", { "fg": s:purple })
 call s:h("cssSelectorOp2", { "fg": s:purple })
 call s:h("cssTagName", { "fg": s:red })
 
+" Fish Shell
+call s:h("fishKeyword", { "fg": s:purple })
+call s:h("fishConditional", { "fg": s:purple })
+
 " Go
 call s:h("goDeclaration", { "fg": s:purple })
 


### PR DESCRIPTION
In the fish shell, the keyword 'end' is used both as a keyword and for
ending conditional logic.

For example, in the trivial function below, the word `end` is used to
terminate the "if" conditional, and it's also used as a keyword to
indicate the end of the function.

This tweak makes the word the same color in both places. I selected
purple to match the Onedark scheme in Atom.

```fish
function foo
    if not string length $argv
        echo "I got nothing."
    end
end
```

Screenshot from Atom showing the desired effect:

![screen shot 2018-12-18 at 19 32 57](https://user-images.githubusercontent.com/5694899/50193413-1cd13e80-02fc-11e9-89b4-a85ccc7ab522.png)

Screenshot of Vim before my change. Note that the `end` doesn't match the `if`. This made my eye twitch. 

![screen shot 2018-12-18 at 19 59 15](https://user-images.githubusercontent.com/5694899/50194229-8b63cb80-02ff-11e9-8bbc-395be548ae18.png)


Screenshot of Vim AFTER my change. It doesn't match Atom completely, but that's largely due to the [vim-fish](https://github.com/dag/vim-fish) plugin I'm using for syntax. At least `function`, `if`, and `end` are the same color. 

![screen shot 2018-12-18 at 19 57 36](https://user-images.githubusercontent.com/5694899/50194171-4a6bb700-02ff-11e9-8290-91239b906236.png)
