### PR TITLE
End of line

### DIFF
--- a/colors/onedark.vim
+++ b/colors/onedark.vim
@@ -259,6 +259,7 @@ call s:h("Visual", { "fg": s:visual_black, "bg": s:visual_grey }) " Visual mode 
 call s:h("VisualNOS", { "bg": s:visual_grey }) " Visual mode selection when vim is "Not Owning the Selection". Only X11 Gui's gui-x11 and xterm-clipboard supports this.
 call s:h("WarningMsg", { "fg": s:yellow }) " warning messages
 call s:h("WildMenu", { "fg": s:black, "bg": s:blue }) " current match in 'wildmenu' completion
+call s:h("EndOfBuffer", { "fg": s:black, "bg": s:black }) " make end of buffer '~' disappear
 
 " }}}
 

--- a/colors/onedark.vim
+++ b/colors/onedark.vim
@@ -248,6 +248,8 @@ call s:h("SpellLocal", { "fg": s:dark_yellow }) " Word that is recognized by the
 call s:h("SpellRare", { "fg": s:dark_yellow }) " Word that is recognized by the spellchecker as one that is hardly ever used. spell This will be combined with the highlighting used otherwise.
 call s:h("StatusLine", { "fg": s:white, "bg": s:cursor_grey }) " status line of current window
 call s:h("StatusLineNC", { "fg": s:comment_grey }) " status lines of not-current windows Note: if this is equal to "StatusLine" Vim will use "^^^" in the status line of the current window.
+call s:h("StatusLineTerm", { "fg": s:white, "bg": s:cursor_grey }) " status line of current :terminal window
+call s:h("StatusLineTermNC", { "fg": s:comment_grey }) " status line of non-current :terminal window
 call s:h("TabLine", { "fg": s:comment_grey }) " tab pages line, not active tab page label
 call s:h("TabLineFill", {}) " tab pages line, where there are no labels
 call s:h("TabLineSel", { "fg": s:white }) " tab pages line, active tab page label


### PR DESCRIPTION
Another small edit to the colorscheme. I am not sure if this is something you want, but I find it looks prettier this way. 

I remove the '~' characters at end of buffer, rendering a cleaner ui.
<img width="122" alt="image" src="https://user-images.githubusercontent.com/26711805/50918467-957d7380-1440-11e9-88a7-9b85ebb58440.png">
