### PR TITLE
Added optional setting for end of buffer tildes

### DIFF
--- a/colors/onedark.vim
+++ b/colors/onedark.vim
@@ -67,11 +67,6 @@ if !exists("g:onedark_terminal_italics")
   let g:onedark_terminal_italics = 0
 endif
 
-" If you want to remove tildes ('~') at end of buffer, opt in
-if !exists("g:onedark_hide_endofbuffer")
-    let g:onedark_hide_endofbuffer = 0
-endif
-
 " This function is based on one from FlatColor: https://github.com/MaxSt/FlatColor/
 " Which in turn was based on one found in hemisu: https://github.com/noahfrederick/vim-hemisu/
 let s:group_colors = {} " Cache of default highlight group settings, for later reference via `onedark#extend_highlight`
@@ -264,8 +259,8 @@ call s:h("Visual", { "fg": s:visual_black, "bg": s:visual_grey }) " Visual mode 
 call s:h("VisualNOS", { "bg": s:visual_grey }) " Visual mode selection when vim is "Not Owning the Selection". Only X11 Gui's gui-x11 and xterm-clipboard supports this.
 call s:h("WarningMsg", { "fg": s:yellow }) " warning messages
 call s:h("WildMenu", { "fg": s:black, "bg": s:blue }) " current match in 'wildmenu' completion
-if g:onedark_hide_endofbuffer
-    call s:h("EndOfBuffer", { "fg": s:black, "bg": s:black }) " Remove '~' at end of buffer for cleaner look
+if get(g:, 'onedark_hide_endofbuffer', 1)
+    call s:h("EndOfBuffer", { "fg": s:black, "bg": s:black }) " Remove '~' at end of buffer for cleaner look. Opt-in in vimrc
 endif
 
 " }}}

--- a/colors/onedark.vim
+++ b/colors/onedark.vim
@@ -67,6 +67,11 @@ if !exists("g:onedark_terminal_italics")
   let g:onedark_terminal_italics = 0
 endif
 
+" If you want to remove tildes ('~') at end of buffer, opt in
+if !exists("g:onedark_hide_endofbuffer")
+    let g:onedark_hide_endofbuffer = 0
+endif
+
 " This function is based on one from FlatColor: https://github.com/MaxSt/FlatColor/
 " Which in turn was based on one found in hemisu: https://github.com/noahfrederick/vim-hemisu/
 let s:group_colors = {} " Cache of default highlight group settings, for later reference via `onedark#extend_highlight`
@@ -259,6 +264,9 @@ call s:h("Visual", { "fg": s:visual_black, "bg": s:visual_grey }) " Visual mode 
 call s:h("VisualNOS", { "bg": s:visual_grey }) " Visual mode selection when vim is "Not Owning the Selection". Only X11 Gui's gui-x11 and xterm-clipboard supports this.
 call s:h("WarningMsg", { "fg": s:yellow }) " warning messages
 call s:h("WildMenu", { "fg": s:black, "bg": s:blue }) " current match in 'wildmenu' completion
+if g:onedark_hide_endofbuffer
+    call s:h("EndOfBuffer", { "fg": s:black, "bg": s:black }) " Remove '~' at end of buffer for cleaner look
+endif
 
 " }}}
 

--- a/colors/onedark.vim
+++ b/colors/onedark.vim
@@ -221,6 +221,10 @@ call s:h("DiffAdd", { "bg": s:green, "fg": s:black }) " diff mode: Added line
 call s:h("DiffChange", { "fg": s:yellow, "gui": "underline", "cterm": "underline" }) " diff mode: Changed line
 call s:h("DiffDelete", { "bg": s:red, "fg": s:black }) " diff mode: Deleted line
 call s:h("DiffText", { "bg": s:yellow, "fg": s:black }) " diff mode: Changed text within a changed line
+if get(g:, 'onedark_hide_endofbuffer', 0)
+    " If enabled, will style end-of-buffer filler lines (~) to appear to be hidden.
+    call s:h("EndOfBuffer", { "fg": s:black, "bg": s:black }) " filler lines (~) after the last line in the buffer
+endif
 call s:h("ErrorMsg", { "fg": s:red }) " error messages on the command line
 call s:h("VertSplit", { "fg": s:vertsplit }) " the column separating vertically split windows
 call s:h("Folded", { "fg": s:comment_grey }) " line used for closed folds
@@ -259,9 +263,6 @@ call s:h("Visual", { "fg": s:visual_black, "bg": s:visual_grey }) " Visual mode 
 call s:h("VisualNOS", { "bg": s:visual_grey }) " Visual mode selection when vim is "Not Owning the Selection". Only X11 Gui's gui-x11 and xterm-clipboard supports this.
 call s:h("WarningMsg", { "fg": s:yellow }) " warning messages
 call s:h("WildMenu", { "fg": s:black, "bg": s:blue }) " current match in 'wildmenu' completion
-if get(g:, 'onedark_hide_endofbuffer', 1)
-    call s:h("EndOfBuffer", { "fg": s:black, "bg": s:black }) " Remove '~' at end of buffer for cleaner look. Opt-in in vimrc
-endif
 
 " }}}
 


### PR DESCRIPTION
Now the optional setting for the tildes seem to work. I'll gladly add a notice in the README if you want!

If a user sets `let g:onedark_hide_endofbuffer=1` in vimrc then the tildes are removed. Otherwise, keep vim as vim!

:)