### PR TITLE
Add specifics highlights for Go

### DIFF
--- a/colors/onedark.vim
+++ b/colors/onedark.vim
@@ -303,6 +303,7 @@ call s:h("fishConditional", { "fg": s:purple })
 
 " Go
 call s:h("goDeclaration", { "fg": s:purple })
+call s:h("goBuiltins", { "fg": s:cyan })
 call s:h("goFunctionCall", { "fg": s:cyan })
 call s:h("goVarDefs", { "fg": s:red })
 call s:h("goVarAssign", { "fg": s:red })

--- a/colors/onedark.vim
+++ b/colors/onedark.vim
@@ -303,11 +303,19 @@ call s:h("fishConditional", { "fg": s:purple })
 
 " Go
 call s:h("goDeclaration", { "fg": s:purple })
-call s:h("goFunctionCall", { "fg": s:blue })
+call s:h("goFunctionCall", { "fg": s:cyan })
 call s:h("goVarDefs", { "fg": s:red })
 call s:h("goVarAssign", { "fg": s:red })
 call s:h("goVar", { "fg": s:purple })
 call s:h("goConst", { "fg": s:purple })
+call s:h("goType", { "fg": s:purple })
+call s:h("goSignedInts", { "fg": s:purple })
+call s:h("goUnsignedInts", { "fg": s:purple })
+call s:h("goFloats", { "fg": s:purple })
+call s:h("goComplexes", { "fg": s:purple })
+call s:h("goTypeName", { "fg": s:yellow })
+call s:h("goDeclType", { "fg": s:purple })
+call s:h("goTypeDecl", { "fg": s:purple })
 
 " HTML
 call s:h("htmlTitle", { "fg": s:white })

--- a/colors/onedark.vim
+++ b/colors/onedark.vim
@@ -303,6 +303,11 @@ call s:h("fishConditional", { "fg": s:purple })
 
 " Go
 call s:h("goDeclaration", { "fg": s:purple })
+call s:h("goFunctionCall", { "fg": s:blue })
+call s:h("goVarDefs", { "fg": s:red })
+call s:h("goVarAssign", { "fg": s:red })
+call s:h("goVar", { "fg": s:purple })
+call s:h("goConst", { "fg": s:purple })
 
 " HTML
 call s:h("htmlTitle", { "fg": s:white })


### PR DESCRIPTION
Some changes to make onedark more like Atom with Go.

Before - After picture
<img width="1051" alt="onedark" src="https://user-images.githubusercontent.com/10519347/56969791-2f8b3800-6b66-11e9-9130-6abcbaf3ed0d.png">

init.vim if it helps
```
call plug#begin()

" General plugins
Plug 'joshdick/onedark.vim'
Plug 'sheerun/vim-polyglot'

call plug#end()

let g:go_highlight_functions = 1
let g:go_highlight_function_calls = 1
let g:go_highlight_variable_declarations = 1
let g:go_highlight_variable_assignments = 1
let g:go_highlight_types = 1

set termguicolors
set background=dark
color onedark
```