### PR TITLE
Fix alacritty cursor colors configuration

### DIFF
--- a/term/One Dark.alacritty
+++ b/term/One Dark.alacritty
@@ -7,8 +7,8 @@ colors:
 
   # Cursor colors
   cursor:
-    background: '0xabb2bf'
-    foreground: '0x282c34'
+    text: '0x282c34'
+    cursor: '0xabb2bf'
 
   # Normal colors
   normal:


### PR DESCRIPTION
We should use `text` and `cursor` for the cursor colors configuration. Otherwise, it would default to being the inverse of the cell color . See https://github.com/jwilm/alacritty/blob/master/alacritty.yml%23L188 for the default configuration file `alacritty.yml`.