### PR TITLE
Consistent highlighting for special characters

### DIFF
--- a/colors/onedark.vim
+++ b/colors/onedark.vim
@@ -192,7 +192,7 @@ call s:h("StorageClass", { "fg": s:yellow }) " static, register, volatile, etc.
 call s:h("Structure", { "fg": s:yellow }) " struct, union, enum, etc.
 call s:h("Typedef", { "fg": s:yellow }) " A typedef
 call s:h("Special", { "fg": s:blue }) " any special symbol
-call s:h("SpecialChar", {}) " special character in a constant
+call s:h("SpecialChar", { "fg": s:dark_yellow }) " special character in a constant
 call s:h("Tag", {}) " you can use CTRL-] on this
 call s:h("Delimiter", {}) " character that needs attention
 call s:h("SpecialComment", { "fg": s:comment_grey }) " special things inside a comment
@@ -438,7 +438,7 @@ call s:h("perlMatchStartEnd",{ "fg": s:blue })
 call s:h("perlMethod", { "fg": s:purple })
 call s:h("perlPOD", { "fg": s:comment_grey })
 call s:h("perlSharpBang", { "fg": s:comment_grey })
-call s:h("perlSpecialString",{ "fg": s:cyan })
+call s:h("perlSpecialString",{ "fg": s:dark_yellow })
 call s:h("perlStatementFiledesc", { "fg": s:red })
 call s:h("perlStatementFlow",{ "fg": s:red })
 call s:h("perlStatementInclude", { "fg": s:purple })


### PR DESCRIPTION
`SpecialChar` currently has no highlighting (cause of #222), but the majority of
other existing `Special` characters in the theme are highlighted as
dark yellow (`htmlSpecialChar`, `texSpecialChar`.)

So, add dark yellow highlighting for `SpecialChar` and change
`perlSpecialString` accordingly, so special characters are highlighted
consistently across all languages.

Resolves #222.

Closes #237.