### PR TITLE
Add support for Neovim LSP

### DIFF
--- a/colors/onedark.vim
+++ b/colors/onedark.vim
@@ -629,6 +629,21 @@ endif
 
 " }}}
 
+" Neovim LSP colors {{{
+
+if has("nvim")
+  call s:h("LspDiagnosticsDefaultError", { "fg": s:red })
+  call s:h("LspDiagnosticsDefaultWarning", { "fg": s:yellow })
+  call s:h("LspDiagnosticsDefaultInformation", { "fg": s:white })
+  call s:h("LspDiagnosticsDefaultHint", { "fg": s:comment_grey })
+  call s:h("LspDiagnosticsUnderlineError", { "fg": s:red, "gui": "underline", "cterm": "underline" })
+  call s:h("LspDiagnosticsUnderlineWarning", { "fg": s:yellow, "gui": "underline", "cterm": "underline" })
+  call s:h("LspDiagnosticsUnderlineInformation", { "fg": s:white, "gui": "underline", "cterm": "underline" })
+  call s:h("LspDiagnosticsUnderlineHint", { "fg": s:comment_grey, "gui": "underline", "cterm": "underline" })
+endi
+
+" }}}
+
 " Must appear at the end of the file to work around this oddity:
 " https://groups.google.com/forum/#!msg/vim_dev/afPqwAFNdrU/nqh6tOM87QUJ
 set background=dark

--- a/colors/onedark.vim
+++ b/colors/onedark.vim
@@ -604,9 +604,10 @@ hi link gitcommitUnmergedArrow gitcommitUnmergedFile
 
 " }}}
 
-" Neovim terminal colors {{{
+" Neovim-Specific Highlighting {{{
 
 if has("nvim")
+  " Neovim terminal colors {{{
   let g:terminal_color_0 =  s:black.gui
   let g:terminal_color_1 =  s:red.gui
   let g:terminal_color_2 =  s:green.gui
@@ -625,13 +626,8 @@ if has("nvim")
   let g:terminal_color_15 = s:comment_grey.gui
   let g:terminal_color_background = g:terminal_color_0
   let g:terminal_color_foreground = g:terminal_color_7
-endif
-
-" }}}
-
-" Neovim LSP colors {{{
-
-if has("nvim")
+  " }}}
+  " Neovim LSP colors {{{
   call s:h("LspDiagnosticsDefaultError", { "fg": s:red })
   call s:h("LspDiagnosticsDefaultWarning", { "fg": s:yellow })
   call s:h("LspDiagnosticsDefaultInformation", { "fg": s:white })
@@ -640,7 +636,8 @@ if has("nvim")
   call s:h("LspDiagnosticsUnderlineWarning", { "fg": s:yellow, "gui": "underline", "cterm": "underline" })
   call s:h("LspDiagnosticsUnderlineInformation", { "fg": s:white, "gui": "underline", "cterm": "underline" })
   call s:h("LspDiagnosticsUnderlineHint", { "fg": s:comment_grey, "gui": "underline", "cterm": "underline" })
-endi
+" }}}
+endif
 
 " }}}
 


### PR DESCRIPTION
Neovim v0.5 will soon ship with a LSP client. They recently have added highlights for diagnostic messages from LSP servers, see [:lsp-highlight](https://github.com/neovim/neovim/blob/08c0eef52a31f70190fd4aa0ea8d54c0a169b284/runtime/doc/lsp.txt#L376). This pull request adds support for them.

I didn't add lines for `LspDiagnosticsVirtual*`, `LspDiagnosticsSigns*` and `LspDiagnosticsHint*` highlights since the they are linked to their corresponding `LspDiagnosticsDefault` by default as the doc mentions.