### PR TITLE
Do not overwrite scheme-wide colors with extend_highlight

### DIFF
--- a/colors/onedark.vim
+++ b/colors/onedark.vim
@@ -75,7 +75,7 @@ function! s:h(group, style, ...)
     let s:highlight = s:group_colors[a:group]
     for style_type in ["fg", "bg", "sp"]
       if (has_key(a:style, style_type))
-        let l:default_style = (has_key(s:highlight, style_type) ? s:highlight[style_type] : { "cterm16": "NONE", "cterm": "NONE", "gui": "NONE" })
+        let l:default_style = (has_key(s:highlight, style_type) ? copy(s:highlight[style_type]) : { "cterm16": "NONE", "cterm": "NONE", "gui": "NONE" })
         let s:highlight[style_type] = extend(l:default_style, a:style[style_type])
       endif
     endfor


### PR DESCRIPTION
Fixes #220

Create a copy of color dictionary and apply changes to it instead of the original.

## Explanation of Problem

Currently, calling `extend_highlight()` will overwrite scheme-defined color dictionaries under the following conditions:

1. Call `extend_highlight()` on a Highlight Group and pass new values for a property (`"fg"` or `"bg"`)
2. The passed property (`"fg"` or `"bg"`) for that Highlight Group was previously assigned a scheme-defined color dictionary

Examples of how this causes unexpected behavior:

### Ex 1: Issue #220 

User calls `onedark#extend_highlight('Normal', {'bg': {'gui': 'NONE'}})` in order to have a transparent background.

`s:group_colors["Normal"].bg` was previously assigned `s:black` [in](https://github.com/joshdick/onedark.vim/blob/94ff495eac89cea2532d8e0022f67c79a24d9649/colors/onedark.vim#L86-L87) `s:h()` [via this line](https://github.com/joshdick/onedark.vim/blob/94ff495eac89cea2532d8e0022f67c79a24d9649/colors/onedark.vim#L240)

`s.black` references the [vim dictionary originally created in "autoload/onedark.vim"](https://github.com/joshdick/onedark.vim/blob/94ff495eac89cea2532d8e0022f67c79a24d9649/autoload/onedark.vim#L15), `{ "gui": "#282C34", "cterm": "235", "cterm16": "0" }`

When `extend_highlight()` is called, `extend(l:default_style, a:style[style_type])` [on line 79 in "colors/onedark.vim"](https://github.com/joshdick/onedark.vim/blob/94ff495eac89cea2532d8e0022f67c79a24d9649/colors/onedark.vim#L79) overwrites the dictionary such that `s:black` is now `{ "gui": "NONE", "cterm": "235", "cterm16": "0" }`. To verify, you can run the ex command `:echo onedark#GetColors().black`

The airline theme uses the modified `s:black` causing the following highlighting:
![image](https://user-images.githubusercontent.com/10344883/109189121-a7761980-7761-11eb-97e5-bb0d9d5a51f8.png)

### Ex 2: Switching Color Schemes on the Fly

Use `extend_highlight()` to change foreground color of 'Repeat' to yellow:

`call onedark#extend_highlight('Repeat', {'fg': {'gui': '#E5C07B'}})`

At first, behavior is expected. Only 'Repeat' has changed:
![image](https://user-images.githubusercontent.com/10344883/109189886-83670800-7762-11eb-9179-5e33228391da.png)

Switch to another color scheme and then back to 'onedark':

`:colorscheme default`
`:colorscheme onedark`

All Highlight Groups that once had a purple foreground are now yellow:
![image](https://user-images.githubusercontent.com/10344883/109190506-2586f000-7763-11eb-9817-16c9d46de65c.png)

This is because `s:purple.gui` has been changed to: `"#E5C07B"`

To be fair, this use case and the one in #220 would be better solved with #set_highlight(), thus avoiding the issue. But there are reasonable uses of extend_highlight that could cause problems. For instance if a user wanted to change the shade of yellow on 'Search' background without changing the foreground color. Using extend_highlight would overwrite s:yellow. 

## Fix

To fix this, simply make a copy of the color dictionary (using built-in function `copy`),  apply changes to the copy, and assign the altered copy to the user-specified Highlight Group. 

Another solution would be to use the built-in `extendnew` instead of `extend` on line 79, but `extendnew` [was just recently added to vim](https://github.com/vim/vim/commit/b0e6b513648db7035046613431a4aa9d71ef4653) and would only solve the problem for those with a bleeding edge version of vim.


