### PR TITLE
add term mode colors to airline theme

### DIFF
--- a/autoload/airline/themes/onedark.vim
+++ b/autoload/airline/themes/onedark.vim
@@ -69,6 +69,17 @@ function! airline#themes#onedark#refresh()
         \ 'airline_c': [ group[0], '', group[2], '', '' ]
         \ }
 
+  " Match :term colors
+  let g:airline#themes#onedark#palette.terminal =
+      \ airline#themes#generate_color_map(s:I1, s:I2, s:I3)
+  let g:airline#themes#onedark#palette.terminal.airline_term = s:I3
+  let g:airline#themes#onedark#palette.normal.airline_term = s:N3
+  let g:airline#themes#onedark#palette.normal_modified.airline_term = s:N3
+  let g:airline#themes#onedark#palette.visual.airline_term = s:V3
+  let g:airline#themes#onedark#palette.visual_modified.airline_term = s:V3
+  let g:airline#themes#onedark#palette.inactive.airline_term = s:IA2
+  let g:airline#themes#onedark#palette.inactive_modified.airline_term = s:IA2
+
   " Warning/Error styling code from vim-airline's ["base16" theme](https://github.com/vim-airline/vim-airline-themes/blob/master/autoload/airline/themes/base16.vim)
 
   " Warnings


### PR DESCRIPTION
Colors in the airline bar in term mode. Normal and Visual mode don't make much sense but as e.g. neovim allows them, match those as well.

![Screenshot 2021-09-11 at 19 34 54](https://user-images.githubusercontent.com/4548767/132983346-57c695a8-8f80-4598-a751-523258d549c9.png)
![Screenshot 2021-09-11 at 19 35 17](https://user-images.githubusercontent.com/4548767/132983349-418da25b-
![Screenshot 2021-09-11 at 19 36 59](https://user-images.githubusercontent.com/4548767/132983352-b0429705-779d-46fc-a569-4c1ca62bf293.png)
03dd-46d5-9cf5-784345f14b1e.png)
![Screenshot 2021-09-11 at 19 35 31](https://user-images.githubusercontent.com/4548767/132983350-c8463355-6ef6-4052-bb1f-e29a279bb4ce.png)

There is also pr on the airline themes repo https://github.com/vim-airline/vim-airline-themes/pull/262