### PR TITLE
feat: support CocFadeOut

### DIFF
--- a/colors/onedark.vim
+++ b/colors/onedark.vim
@@ -596,6 +596,7 @@ call s:h("CocErrorSign", { "fg": s:red })
 call s:h("CocWarningSign", { "fg": s:yellow })
 call s:h("CocInfoSign", { "fg": s:blue })
 call s:h("CocHintSign", { "fg": s:cyan })
+call s:h("CocFadeOut", { "fg": s:special_grey })
 
 " neomake/neomake
 call s:h("NeomakeErrorSign", { "fg": s:red })

--- a/colors/onedark.vim
+++ b/colors/onedark.vim
@@ -596,7 +596,7 @@ call s:h("CocErrorSign", { "fg": s:red })
 call s:h("CocWarningSign", { "fg": s:yellow })
 call s:h("CocInfoSign", { "fg": s:blue })
 call s:h("CocHintSign", { "fg": s:cyan })
-call s:h("CocFadeOut", { "fg": s:special_grey })
+call s:h("CocFadeOut", { "fg": s:comment_grey })
 
 " neomake/neomake
 call s:h("NeomakeErrorSign", { "fg": s:red })


### PR DESCRIPTION
Support `CocFadeOut` and by extension `CocUnusedHighlight` for highlighting unnecessary code.

Uses `special_grey`, looks like:

![image](https://user-images.githubusercontent.com/25565697/139842732-3103e301-171b-4902-b13e-ffdc004f5258.png)
