### PR TITLE
fix: allow extend_highlight to set cterm attr-list

### DIFF
--- a/colors/onedark.vim
+++ b/colors/onedark.vim
@@ -85,6 +85,9 @@ function! s:h(group, style, ...)
     if (has_key(a:style, "gui"))
       let s:highlight.gui = a:style.gui
     endif
+    if (has_key(a:style, "cterm"))
+      let s:highlight.cterm = a:style.cterm
+    endif
   else
     let s:highlight = a:style
     let s:group_colors[a:group] = s:highlight " Cache default highlight group settings


### PR DESCRIPTION
this fixes what looks like a simple oversight.  The `gui` attr-list is copied over in calls to `onedark#extend_highlight`, but not `cterm`.