### PR TITLE
Change Selection Background in onedark.kitty to be consistatn with th…

### DIFF
--- a/term/One Dark.kitty
+++ b/term/One Dark.kitty
@@ -6,7 +6,7 @@ cursor_text_color        #2c323c
 foreground               #abb2bf
 background               #282c34
 selection_foreground     #2c323c
-selection_background     #5c6370
+selection_background     #abb2bf
 
 # Black
 color0                   #2c323c


### PR DESCRIPTION
The `selection_background` variable is set to `#5c6370` in the `Term/onedark.kitty` theme. This is inconsistant with the selection background in the Vim theme. The selection background in the Vim theme is set to `#abb2bf`. I made the chane, and it now looks consistant.